### PR TITLE
Fix travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,6 @@ r:
 sudo: false
 cache: packages
 
-# dependency for gsl>copula>zinbwave
-addons:
-  apt:
-    packages:
-      - gsl-bin
-      - libgsl-dev
-
 after_success:
   - Rscript -e 'covr::codecov()'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ r:
 sudo: false
 cache: packages
 
+install:
+  - R -e 'install.packages("devtools")'
+  - R -e 'devtools::install(dependencies = TRUE, upgrade_dependencies = TRUE)'
+
 after_success:
   - Rscript -e 'covr::codecov()'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,13 @@ r:
 sudo: false
 cache: packages
 
+# dependency for gsl>copula>zinbwave
+addons:
+  apt:
+    packages:
+      - gsl-bin
+      - libgsl-dev
+
 after_success:
   - Rscript -e 'covr::codecov()'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 
 language: R
 r:
-  - bioc-devel
   - bioc-release
 sudo: false
 cache: packages
@@ -14,8 +13,7 @@ addons:
       - gsl-bin
       - libgsl-dev
 
-after_success:
-  - Rscript -e 'covr::codecov()'
+r_check_args: "--no-clean --no-codoc --no-examples --no-install --no-tests --no-manual --no-vignettes --no-build-vignettes",
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,12 @@ r:
 sudo: false
 cache: packages
 
+# dependency for gsl>copula>zinbwave
+addons:
+  apt:
+    packages:
+      - libgsl-dev
+
 install:
   - R -e 'install.packages("devtools")'
   - R -e 'devtools::install(dependencies = TRUE, upgrade_dependencies = TRUE)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 
 language: R
 r:
+  - bioc-devel
   - bioc-release
 sudo: false
 cache: packages
@@ -13,7 +14,8 @@ addons:
       - gsl-bin
       - libgsl-dev
 
-r_check_args: "--no-clean --no-codoc --no-examples --no-install --no-tests --no-manual --no-vignettes --no-build-vignettes"
+after_success:
+  - Rscript -e 'covr::codecov()'
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
       - gsl-bin
       - libgsl-dev
 
-r_check_args: "--no-clean --no-codoc --no-examples --no-install --no-tests --no-manual --no-vignettes --no-build-vignettes",
+r_check_args: "--no-clean --no-codoc --no-examples --no-install --no-tests --no-manual --no-vignettes --no-build-vignettes"
 
 notifications:
   email:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,8 @@ Imports:
     scales,
     stats,
     SummarizedExperiment,
-    utils
+    utils,
+    zinbwave
 Suggests:
     BiocStyle,
     covr,
@@ -54,7 +55,6 @@ Suggests:
     scran,
     mfa,
     phenopath,
-    zinbwave,
     BASiCS
 biocViews: SingleCell, RNASeq, Transcriptomics, GeneExpression, Sequencing,
     Software

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,8 +37,7 @@ Imports:
     scales,
     stats,
     SummarizedExperiment,
-    utils,
-    zinbwave
+    utils
 Suggests:
     BiocStyle,
     covr,
@@ -55,7 +54,8 @@ Suggests:
     scran,
     mfa,
     phenopath,
-    BASiCS
+    BASiCS,
+    zinbwave
 biocViews: SingleCell, RNASeq, Transcriptomics, GeneExpression, Sequencing,
     Software
 URL: https://github.com/Oshlack/splatter


### PR DESCRIPTION
Hello Luke, Belinda, and Alicia,

Wouter and I noticed splatter wasn't passing the travis tests. We had a look and fixed two small issues:
- Added zimbwave to imports instead of suggests (25540a9)
- Added libgsl-dev apt package to be installed, for gsl/copula/zinbwave (2ea64a1)

You can check [our travis](https://travis-ci.org/dynverse/splatter/jobs/304827710) to see that splatter is now able to build.

Kind regards,
@Zouter and @rcannood