### PR TITLE
Fix bug in reversing directions for factors less than one

### DIFF
--- a/R/splat-simulate.R
+++ b/R/splat-simulate.R
@@ -819,8 +819,7 @@ getLNormFactors <- function(n.facs, sel.prob, neg.prob, fac.loc, fac.scale) {
     dir.selected <- (-1) ^ rbinom(n.selected, 1, neg.prob)
     facs.selected <- rlnorm(n.selected, fac.loc, fac.scale)
     # Reverse directions for factors that are less than one
-    dir.selected[facs.selected < 1 & dir.selected == -1] <- 1
-    dir.selected[facs.selected < 1 & dir.selected == 1] <- -1
+    dir.selected[facs.selected < 1] <- -1 * dir.selected[facs.selected < 1]
     factors <- rep(1, n.facs)
     factors[is.selected] <- facs.selected ^ dir.selected
 


### PR DESCRIPTION
This fixes a bug where the lognormal multipliers don't faithfully reflect `de.downProb`.

Problem statement:

In the deleted excerpt, `dir.selected[facs.selected < 1 & dir.selected == 1] <- -1` acts on the entries converted in the previous step, `dir.selected[facs.selected < 1 & dir.selected == -1] <- 1`. As a result, there will be, on average, more multipliers greater than 1 than those less than 1 than expected for any given `de.downProb`. 